### PR TITLE
2025年度運用向け変更

### DIFF
--- a/app/Http/Controllers/CommiEntry_infoController.php
+++ b/app/Http/Controllers/CommiEntry_infoController.php
@@ -97,7 +97,7 @@ class CommiEntry_infoController extends AppBaseController
         // 通知メールCC送信先取得
         $gm_email = GmAddress::where('uuid', $id)->first();
 
-        return view('admin_entry_infos.show', compact('entryInfo', 'gm_email'));
+        return view('commi_entry_infos.show', compact('entryInfo', 'gm_email'));
     }
 
     /**

--- a/app/Http/Controllers/CommiEntry_infoController.php
+++ b/app/Http/Controllers/CommiEntry_infoController.php
@@ -282,9 +282,7 @@ class CommiEntry_infoController extends AppBaseController
 
         Flash::success($userinfo->user->name . 'さんの副申請書を作成しました。');
 
-        $entryInfos = User::whereHas('entry_info', function ($query) {
-            $query->where('district', Auth::user()->is_commi);
-        })->with('entry_info')->get();
+        $entryInfos = Entry_info::where('district', Auth::user()->is_commi)->with('user')->get();
 
         return view('commi_entry_infos.index')
             ->with('entryInfos', $entryInfos);

--- a/app/Http/Controllers/Entry_infoController.php
+++ b/app/Http/Controllers/Entry_infoController.php
@@ -311,8 +311,7 @@ class Entry_infoController extends AppBaseController
 
     public function pdf()
     {
-        $entryInfo = User::where('id', Auth::id())->with('entry_info')
-            ->with('entry_info')->first();
+        $entryInfo = Entry_Info::where('user_id', Auth::id())->with('user')->with('health_info')->first();
 
         $pdf = \PDF::loadView('entry_infos.pdf', compact('entryInfo'));
         $pdf->setPaper('A4');

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -36,7 +36,7 @@ class AuthServiceProvider extends ServiceProvider
                 ->line('AISESで申し込み手続きをするには、以下のボタンをクリックしてメール認証を完了してください。')
                 ->action('認証する', $url)
                 ->line('メール認証が完了したら、ユーザーマニュアルを参照の上、申込書を作成してください。')
-                ->line('もし、このメールにお心当たりが無い場合は、wb-system@scout.tokyo までご連絡ください。');
+                ->line('もし、このメールにお心当たりが無い場合は、wb-system-contact@scout.tokyo までご連絡ください。');
         });
 
         Gate::define('admin', function (\App\Models\User $user) {

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -78,7 +78,7 @@
                     <th>サポート</td>
                     <td>
                         使用方法などのお問い合わせは、各地区のAIS委員長までお願い致します。<br>
-                        システムに関する技術的なお問い合わせは <a href="mailto:{{ config('mail.from.address') }}">専用アドレス</a>
+                        システムに関する技術的なお問い合わせは <a href="mailto:wb-system-contact@scout.tokyo">専用アドレス</a>
                         にお送りください。
                     </td>
                 </tr>

--- a/resources/views/admin_entry_infos/fields.blade.php
+++ b/resources/views/admin_entry_infos/fields.blade.php
@@ -133,7 +133,7 @@
             <td>生年月日</td>
             <td>
                 {{-- {!! Form::date('birthday', null, ['class' => 'form-control', 'min'=>'1947-01-01', 'max'=>'2004-12-31']) !!} --}}
-                {!! Form::selectRange('bd_year', 1942, 2005, null, [
+                {!! Form::selectRange('bd_year', 1942, 2008, null, [
                     'class' => 'form-control custom-select uk-form-width-small',
                     'placeholder' => '年',
                 ]) !!}

--- a/resources/views/commi_entry_infos/priority.blade.php
+++ b/resources/views/commi_entry_infos/priority.blade.php
@@ -74,7 +74,7 @@
         </div>
         <script type="text/javascript" src="{{ asset('js/jquery.min.js') }}"></script>
         <script src="{{ asset('js/jquery-ui.min.js') }}"></script>
-        <script type="text/javascript" src="{{ asset('js/datatables.min.js') }}"></script>
+        <script type="text/javascript" src="{{ asset('js/dataTables.min.js') }}"></script>
 
         <script type="text/javascript">
             $(function() {

--- a/resources/views/commi_entry_infos/show.blade.php
+++ b/resources/views/commi_entry_infos/show.blade.php
@@ -8,7 +8,7 @@
                     <h1>申込内容詳細</h1>
                 </div>
                 <div class="col-sm-6">
-                    <a class="btn btn-default float-right" href="{{ route('admin_entryInfos.index') }}">
+                    <a class="btn btn-default float-right" href="{{ route('commi_entryInfos.index') }}">
                         戻る
                     </a>
                 </div>

--- a/resources/views/emails/ais_accepted.blade.php
+++ b/resources/views/emails/ais_accepted.blade.php
@@ -16,7 +16,7 @@
     また、課程別研修を申し込まれている場合は、スカウトコース修了後に課程別研修の参加可否をお知らせします。
 </p>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/emails/ais_checked.blade.php
+++ b/resources/views/emails/ais_checked.blade.php
@@ -2,9 +2,9 @@
 <p>ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}から自動送信しています。</p>
 <p>地区AIS委員会の認定が行われましたのでお知らせ致します。</p>
 
-<p>恐れ入りますがもしこの登録にお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>恐れ入りますがもしこの登録にお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/emails/ais_rejected.blade.php
+++ b/resources/views/emails/ais_rejected.blade.php
@@ -8,7 +8,7 @@
 </p>
 
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/emails/commi_checked.blade.php
+++ b/resources/views/emails/commi_checked.blade.php
@@ -7,9 +7,9 @@
 <h3>確認方法</h3>
 <a href="{{ url('/') }}">システム</a>にログインしてご確認ください<br>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/emails/input_registerd.blade.php
+++ b/resources/views/emails/input_registerd.blade.php
@@ -21,9 +21,9 @@
     <li>また申込内容に不備があった場合、参加申込をお断りしますのでご注意ください。</li>
 </ul>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/emails/reminderEmailForFee.blade.php
+++ b/resources/views/emails/reminderEmailForFee.blade.php
@@ -7,9 +7,9 @@
     ご不明な点は、<a href="mailto:ais@scout.tokyo">東京連盟事務局</a>までお問い合わせください。
 </p>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/emails/resetNoticeEmailForFee.blade.php
+++ b/resources/views/emails/resetNoticeEmailForFee.blade.php
@@ -37,9 +37,9 @@
 
 <p>本メールと行き違いでお振り込みの場合はご容赦ください。</p>
 
-<p>恐れ入りますがもしこの登録にお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>恐れ入りますがもしこの登録にお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/entry_infos/fields.blade.php
+++ b/resources/views/entry_infos/fields.blade.php
@@ -129,7 +129,7 @@
         <tr>
             <td>生年月日</td>
             <td>
-                {!! Form::selectRange('bd_year', 1942, 2005, null, [
+                {!! Form::selectRange('bd_year', 1942, 2008, null, [
                     'class' => 'form-control custom-select uk-form-width-small',
                     'placeholder' => '年',
                 ]) !!}年{!! Form::selectrange('bd_month', 1, 12, null, [

--- a/resources/views/mail/feechecked.blade.php
+++ b/resources/views/mail/feechecked.blade.php
@@ -9,9 +9,9 @@
 <h3>登録情報の確認方法</h3>
 ご自身のメールアドレスとパスワードで<a href="{{ url('/') }}">システム</a>にログインしてご確認ください。<br>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/mail/gm_confirm.blade.php
+++ b/resources/views/mail/gm_confirm.blade.php
@@ -7,9 +7,9 @@
 <h3>確認方法</h3>
 <a href="{{ url('/') }}">システム</a>にログインしてご確認ください<br>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/mail/gm_request.blade.php
+++ b/resources/views/mail/gm_request.blade.php
@@ -8,9 +8,9 @@
 <a href="{{ url('/confirm/gm?uuid=') }}{{ $uuid }}">{{ url('/confirm/gm?uuid=') }}{{ $uuid }}</a>にアクセスして参加承認を行ってください。<br>
 <p>ご参考: <a href="https://wbsc.scout.tokyo/howto_gm">団承認の仕方</a></p>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/mail/trainer_confirm.blade.php
+++ b/resources/views/mail/trainer_confirm.blade.php
@@ -8,9 +8,9 @@
 <h3>確認方法</h3>
 <a href="{{ url('/') }}">システム</a>にログインしてご確認ください<br>
 
-<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>このメールにお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/mail/trainer_request.blade.php
+++ b/resources/views/mail/trainer_request.blade.php
@@ -8,9 +8,9 @@
 <a href="{{ url('/confirm/trainer?uuid=') }}{{ $uuid }}">{{ url('/confirm/trainer?uuid=') }}{{ $uuid }}</a>にアクセスしてください。<br>
 <p>ご参考: <a href="https://wbsc.scout.tokyo/howto_trainer">トレーナー認定の仕方</a></p>
 
-<p>恐れ入りますがもしこの登録にお心当たりが無い場合は、<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>までご連絡ください。</p>
+<p>恐れ入りますがもしこの登録にお心当たりが無い場合は、<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>までご連絡ください。</p>
 <p></p>
 
 ----<br>
 <a href="{{ config('app.url') }}">ボーイスカウト東京連盟 指導者訓練 参加申込システム {{ config('app.name') }}</a><br>
-<a href="mailto:wb-system@scout.tokyo">wb-system@scout.tokyo</a>
+<a href="mailto:wb-system-contact@scout.tokyo">wb-system-contact@scout.tokyo</a>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -125,7 +125,7 @@
                         <div class="ml-12">
                             <div class="mt-2 text-gray-600 dark:text-gray-400">
                                 <ul class="uk-list">
-                                    <li><a href="https://drive.google.com/file/d/1rS_9yTpuq8VzABUeeVS8TyQLU8jabXqg/view?usp=sharing"
+                                    <li><a href="https://drive.google.com/file/d/1t9sIq9LrjQK051HdllZz1wYSwxssS-JJ/view?usp=drive_link"
                                             target="_blank">参加者マニュアル</a></li>
                                     <li><a href="{{ url('/howto_gm') }}">団委員長 編</a></li>
                                     <li><a href="{{ url('/howto_trainer') }}">トレーナー 編</a></li>


### PR DESCRIPTION
以下の4点を修正しました。マージお願いいたします。
* 東京連盟AIS委員会からの依頼により、生年月日入力欄で2008年生まれまで入力できるよう修正しました
  * 入所条件は年齢と所属隊でチェックするので、誤って入力した参加者は人手で弾く運用回避をするとのこと
* 参加者画面にて指導者研修参加申込書のPDFファイルが生成できないバグを修正しました
  * https://github.com/caffisenna/wbsc-entry/commit/1ff3d3ae00cadac49f708015908b2050057dfe60 の修正漏れと思われます
* 問い合わせ先メールアドレスの変更
* 公開用参加者マニュアルのURLの変更